### PR TITLE
File creation fixes

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -90,7 +90,9 @@ class rundeck::config {
   contain rundeck::config::framework
 
   file { "${properties_dir}/project.properties":
-    ensure => absent,
+      ensure  => file,
+      content => '',
+      mode    => '0400',
   }
 
   file { "${properties_dir}/rundeck-config.properties":

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -90,9 +90,9 @@ class rundeck::config {
   contain rundeck::config::framework
 
   file { "${properties_dir}/project.properties":
-      ensure  => file,
-      content => '',
-      mode    => '0400',
+    ensure  => file,
+    content => '',
+    mode    => '0400',
   }
 
   file { "${properties_dir}/rundeck-config.properties":

--- a/manifests/config/jaas_auth.pp
+++ b/manifests/config/jaas_auth.pp
@@ -16,7 +16,9 @@ class rundeck::config::jaas_auth {
     }
   } else {
     file { "${rundeck::config::properties_dir}/realm.properties":
-      ensure => absent,
+      ensure  => file,
+      content => '',
+      mode    => '0400',
     }
   }
 


### PR DESCRIPTION
The current manifest ensures these files are absent, but the Rundeck RPM will add the files back should Rundeck becomes updated on a system.  This change will empty the files rather than making them absent.